### PR TITLE
feat: 이메일 인증 페이지 구현 (#44)

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,7 @@ import FindPassword from "../user/FindPassword.vue";
 import CustomerCenter from "../admin/customercenter/CustomerCenter.vue"
 import Admin from "../admin/Admin.vue"
 import SignupSuccess from "../user/SignupSuccess.vue";
+import EmailVerification from "../user/EmailVerification.vue";
 
 const routes = [
     {path: "/", component: Main},
@@ -19,6 +20,7 @@ const routes = [
     {path: "/customercenter", component: CustomerCenter},
     {path: "/admin", component: Admin},
     {path: "/signupsuccess", name: 'SignupSuccess', component: SignupSuccess},
+    { path: '/emailverify', name: EmailVerification, component: EmailVerification },
 ]
 
 const router = createRouter({

--- a/src/user/EmailVerification.vue
+++ b/src/user/EmailVerification.vue
@@ -1,0 +1,70 @@
+<template>
+    <div class="w-full h-screen flex justify-center items-center bg-white">
+
+      <div class="w-[500px] h-[650px] bg-white flex flex-col justify-center items-center">
+       
+        <div class="text-center text-black text-6xl font-normal font-['ABeeZee']">
+          인증 코드 확인
+        </div>
+  
+        
+        <div class="text-center text-stone-500 text-base font-normal font-['Helvetica'] mt-4">
+          이메일로 6자리 인증 코드를 발송했습니다.
+        </div>
+        <div class="text-center text-stone-500 text-base font-normal font-['Helvetica'] mt-2">
+          아래에 코드를 입력해주세요.
+        </div>
+  
+        <!-- 이메일 -->
+        <div class="w-96 h-12 mt-4 bg-neutral-50">
+          <div class="text-center justify-start text-zinc-800 text-base font-normal font-['Helvetica']">
+            user@example.com
+          </div>
+        </div>
+  
+        <!-- 인증 코드 입력 박스 -->
+        <div class="flex justify-between w-96 mt-4">
+          <input class="w-14 h-20 bg-neutral-50 border border-gray-300" type="text" maxlength="1" />
+          <input class="w-14 h-20 bg-neutral-50 border border-gray-300" type="text" maxlength="1" />
+          <input class="w-14 h-20 bg-neutral-50 border border-gray-300" type="text" maxlength="1" />
+          <input class="w-14 h-20 bg-neutral-50 border border-gray-300" type="text" maxlength="1" />
+          <input class="w-14 h-20 bg-neutral-50 border border-gray-300" type="text" maxlength="1" />
+          <input class="w-14 h-20 bg-neutral-50 border border-gray-300" type="text" maxlength="1" />
+        </div>
+  
+        <!-- 남은 시간 표시 -->
+        <div class="text-center text-stone-500 text-base font-normal font-['Helvetica'] mt-4">
+          남은 시간 05:00
+        </div>
+  
+
+        <div class="w-96 h-14 bg-purple-700 mt-6 flex justify-center items-center">
+          <div class="text-white text-base font-normal font-['Helvetica']">인증 확인</div>
+        </div>
+  
+        <div class="text-center text-purple-700 text-base font-normal font-['Helvetica'] mt-4">
+          <router-link to="/resend-verification">인증 코드 재발송</router-link>
+        </div>
+
+        <div class="text-center text-stone-500 text-sm font-normal font-['Helvetica'] mt-4">
+          <div>• 이메일 주소를 다시 확인해주세요.</div>
+          <div>• 스팸 메일함을 확인해주세요.</div>
+          <div>• 인증 코드는 발송 후 5분 동안 유효합니다.</div>
+        </div>
+      </div>
+  
+
+      <div class="absolute top-0 left-0 w-full h-full flex justify-center items-center">
+        <div class="size-4 opacity-90 bg-purple-700"></div>
+        <div class="size-4 opacity-80 bg-purple-700"></div>
+        <div class="size-4 opacity-90 bg-purple-700"></div>
+        <div class="size-4 opacity-70 bg-purple-700"></div>
+      </div>
+    </div>
+  </template>
+  
+  <script setup></script>
+  
+  <style scoped>
+  </style>
+  


### PR DESCRIPTION
## #️⃣ Issue Number
#44 이메일 인증 페이지 구현

## 📝 요약(Summary)
회원가입 시 이메일 인증 버튼 -> 이메일 인증 페이지로 이동, 추후 비밀번호 찾기 시에도 적용할 것

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 파일 혹은 폴더명 수정


## 💬 공유사항 to 리뷰어
일단 회원가입시에 이메일 인증 버튼을 누르면 이동 되게끔 했습니다.
추후 비밀번호 찾기 페이지에서도 이동 되도록 연결 예정

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
