### PR TITLE
feat: 공연/전시 하단 카드 리스트 뷰 구성 (#54)

### DIFF
--- a/src/events/EventShowMore.vue
+++ b/src/events/EventShowMore.vue
@@ -5,7 +5,9 @@
   
       <!-- 카테고리 -->
       <Category />
-
+  
+      <!-- 그 아래 이벤트 카드 리스트 -->
+      <EventShowMoreList />
     </div>
   </template>
   
@@ -13,12 +15,13 @@
   import Card from '../main/Card.vue'
   import cardData from '../assets/data/card.json'
   import Category from '../main/Category.vue'
-
+  import EventShowMoreList from './EventShowMoreList.vue'
   
   export default {
     components: {
       Card,
       Category,
+      EventShowMoreList,
     },
     data() {
       return {
@@ -31,4 +34,3 @@
     }
   }
   </script>
-  

--- a/src/events/EventShowMoreCard.vue
+++ b/src/events/EventShowMoreCard.vue
@@ -1,0 +1,25 @@
+<template>
+    <router-link :to="`/event/${id}`" class="block">
+    <div class="w-56 h-80 bg-white rounded-2xl shadow-md flex flex-col">
+      <!-- 상단 색 배경 -->
+      <div :class="['w-full h-64 rounded-2xl', color]"></div>
+  
+      <!-- 텍스트 영역 -->
+      <div class="px-3 mt-3">
+        <p class="text-purple-800 text-base font-semibold truncate">{{ title }}</p>
+        <p class="text-neutral-500 text-sm mt-0.5 truncate">{{ venue }}</p>
+        <p class="text-neutral-500 text-sm mt-0.5">{{ dateRange }}</p>
+      </div>
+    </div>
+    </router-link>
+  </template>
+  
+  <script setup>
+  defineProps({
+  id: Number, // 상세정보에 사용
+  title: String,
+  venue: String,
+  dateRange: String,
+  color: String
+})
+  </script>

--- a/src/events/EventShowMoreList.vue
+++ b/src/events/EventShowMoreList.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="max-w-screen-xl mx-auto grid grid-cols-5 gap-x-4 gap-y-8 mt-10">
+      <EventShowMoreCard
+        v-for="event in events"
+        :key="event.id"
+        :title="event.title"
+        :venue="event.venue"
+        :dateRange="event.dateRange"
+        :color="event.color"
+      />
+    </div>
+  </template>
+  
+  <script setup>
+  import EventShowMoreCard from './EventShowMoreCard.vue'
+  
+  const events = [
+    { id: 1, title: '알라딘', venue: '샤롯데씨어터', dateRange: '2024.11.22 ~ 2025.06.22', color: 'bg-violet-50' },
+    { id: 2, title: '레미제라블', venue: '예술의전당', dateRange: '2025.01.01 ~ 2025.03.01', color: 'bg-purple-100' },
+    { id: 3, title: '지킬앤하이드', venue: '블루스퀘어', dateRange: '2024.12.01 ~ 2025.02.15', color: 'bg-orange-100' },
+    { id: 4, title: '캣츠', venue: '예술의전당', dateRange: '2025.03.10 ~ 2025.05.01', color: 'bg-violet-50' },
+    { id: 5, title: '노트르담 드 파리', venue: 'LG아트센터', dateRange: '2024.10.20 ~ 2025.01.20', color: 'bg-purple-100' },
+    { id: 6, title: '알라딘', venue: '샤롯데씨어터', dateRange: '2024.11.22 ~ 2025.06.22', color: 'bg-violet-50' },
+    { id: 7, title: '레미제라블', venue: '예술의전당', dateRange: '2025.01.01 ~ 2025.03.01', color: 'bg-purple-100' },
+    { id: 8, title: '지킬앤하이드', venue: '블루스퀘어', dateRange: '2024.12.01 ~ 2025.02.15', color: 'bg-orange-100' },
+    { id: 9, title: '캣츠', venue: '예술의전당', dateRange: '2025.03.10 ~ 2025.05.01', color: 'bg-violet-50' },
+    { id: 10, title: '노트르담 드 파리', venue: 'LG아트센터', dateRange: '2024.10.20 ~ 2025.01.20', color: 'bg-purple-100' },
+    { id: 11, title: '알라딘', venue: '샤롯데씨어터', dateRange: '2024.11.22 ~ 2025.06.22', color: 'bg-violet-50' },
+    { id: 12, title: '레미제라블', venue: '예술의전당', dateRange: '2025.01.01 ~ 2025.03.01', color: 'bg-purple-100' },
+    { id: 13, title: '지킬앤하이드', venue: '블루스퀘어', dateRange: '2024.12.01 ~ 2025.02.15', color: 'bg-orange-100' },
+    { id: 14, title: '캣츠', venue: '예술의전당', dateRange: '2025.03.10 ~ 2025.05.01', color: 'bg-violet-50' },
+    { id: 15, title: '노트르담 드 파리', venue: 'LG아트센터', dateRange: '2024.10.20 ~ 2025.01.20', color: 'bg-purple-100' },
+  ]
+  const filteredEvents = events // 나중에 필터 추가 가능
+  </script>


### PR DESCRIPTION
## #️⃣ Issue Number
#54 공연 카드 구현 및 공연/전시 페이지

## 📝 요약(Summary)
카테고리 하단부분의 events 카드 구현 -> 공연/전시 더보기 페이지 구성 완료

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경



## 💬 공유사항 to 리뷰어
메인페이지에서 더보기로 이동할 수 있게 나머지 연결하겠습니다~

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
