### PR TITLE
feat: 공연/전시의 상세페이지 상단 간단정보, 탭 구현 (#63)

### DIFF
--- a/src/events/Detail.vue
+++ b/src/events/Detail.vue
@@ -1,8 +1,44 @@
-<script setup>
-</script>
-
+<!-- src/events/Detail.vue -->
 <template>
-</template>
-
-<style scoped>
-</style>
+    <div class="pt-10 px-20">
+      <EventHeaderInfo v-bind="event" />
+      <EventTabs v-model:tab="selectedTab" />
+      <!-- <EventDetailContent v-if="selectedTab === '상세 정보'" /> -->
+      <!-- 추가: 추천, 게시판, 한줄평 영역도 나중에 연결 가능 -->
+    </div>
+  </template>
+  
+  <script setup>
+  import { useRoute } from 'vue-router'
+  import { ref, computed } from 'vue'
+  import EventHeaderInfo from './EventHeaderInfo.vue'
+  import EventTabs from './EventDetailTab.vue'
+  
+  // 1. 라우터에서 id 가져오기
+  const route = useRoute()
+  const id = Number(route.params.id)
+  
+  // 2. 임시 데이터 (추후 API 대체 가능)
+  const eventList = [
+    {
+      id: 1,
+      title: '알라딘',
+      genre: '뮤지컬',
+      posterUrl: '/images/aladdin.jpg',
+      period: '2025.02.08 ~ 2025.05.11',
+      isOngoing: true,
+      score: 9.5,
+      duration: '150분',
+      ageLimit: '8세 이상',
+      venue: '샤롯데씨어터',
+      price: 'VIP석 110,000원 | R석 99,000원 | S석 77,000원',
+      bookingEarly: '2024.12.22 ~ 2025.01.10',
+      bookingNormal: '2025.01.11 ~ 2025.05.10'
+    },
+    // ... 다른 이벤트들
+  ]
+  
+  const event = computed(() => eventList.find(e => e.id === id))
+  const selectedTab = ref('상세 정보')
+  </script>
+  

--- a/src/events/EventDetailTab.vue
+++ b/src/events/EventDetailTab.vue
@@ -1,0 +1,50 @@
+<template>
+    <div class="w-[1320px] bg-white flex relative">
+      <div
+        v-for="tabName in tabs"  
+        :key="tabName"
+        class="w-28 h-14 bg-white cursor-pointer flex items-center justify-center"
+        @click="$emit('update:tab', tabName)" 
+        >
+        <div
+          :class="[
+            'text-center text-xl font-[Inter]',
+            tabName === tab  
+              ? 'text-violet-600 font-extrabold'
+              : tabName === '게시판'
+              ? 'text-zinc-600 font-medium'
+              : 'text-zinc-600 font-normal'
+          ]"
+        >
+          {{ tabName }}
+        </div>
+      </div>
+  
+      <div
+        class="absolute bottom-0 h-[3px] w-28 bg-violet-600 transition-all duration-300"
+        :style="{ transform: `translateX(${tabIndex * 7}rem)` }"
+      ></div>
+    </div>
+  </template>
+  
+  <script setup>
+  import { computed } from 'vue'
+  
+  // props 이름 : tab
+  const props = defineProps({
+    tab: String,
+  })
+  
+  const emit = defineEmits(['update:tab'])
+  
+  const tabs = ['추천', '상세 정보', '게시판', '한줄평']
+  
+  const tabIndex = computed(() => {
+    const i = tabs.indexOf(props.tab) 
+    return i >= 0 ? i : 0
+  })
+  </script>
+  
+  <style scoped>
+
+  </style>

--- a/src/events/EventHeaderInfo.vue
+++ b/src/events/EventHeaderInfo.vue
@@ -1,0 +1,82 @@
+<template>
+    <div class="w-[1320px] h-80 relative bg-violet-50 rounded-xl mx-auto">
+      <!-- 포스터 이미지 박스 -->
+      <div class="w-44 h-56 absolute left-[48px] top-[67px] bg-amber-300 rounded-[10px] flex items-center justify-center">
+        <!-- 포스터 이미지 실제로 들어갈 곳 -->
+        <img :src="posterUrl" alt="포스터" class="w-24 h-36 object-cover" />
+      </div>
+  
+      <!-- 공연 정보 텍스트 -->
+      <div class="absolute left-[255px] top-[72px]">
+        <div class="flex items-center space-x-2">
+          <span class="text-2xl font-bold text-neutral-800">{{ genre }}</span>
+          <span class="text-2xl font-bold text-neutral-800">{{ title }}</span>
+        </div>
+  
+        <!-- 날짜 & 진행 상태 -->
+        <div class="flex items-center space-x-2 mt-2">
+          <span class="text-sm text-zinc-600">{{ period }}</span>
+          <span v-if="isOngoing" class="px-2 py-0.5 text-sm text-white bg-violet-400 rounded-full">진행중</span>
+          <span v-if="score" class="flex items-center text-yellow-500 text-sm font-semibold">
+            ⭐ {{ score }}
+          </span>
+          <!-- 알림 아이콘 자리 (하트, 벨 등) -->
+          <span class="text-purple-500">❤️</span>
+          <span class="text-purple-500">🔔</span>
+        </div>
+  
+        <!-- 공연 메타 정보 -->
+        <div class="mt-6 p-4 bg-white rounded-xl w-[1024px] shadow-sm">
+          <div class="grid grid-cols-2 gap-y-2 gap-x-10 text-sm">
+            <div class="flex">
+              <span class="w-24 font-bold text-neutral-800">공연 시간</span>
+              <span class="text-zinc-600">{{ duration }}</span>
+            </div>
+            <div class="flex">
+              <span class="w-24 font-bold text-neutral-800">가 격</span>
+              <span class="text-zinc-600">{{ price }}</span>
+            </div>
+            <div class="flex">
+              <span class="w-24 font-bold text-neutral-800">관람 연령</span>
+              <span class="text-zinc-600">{{ ageLimit }}</span>
+            </div>
+            <div class="flex">
+              <span class="w-24 font-bold text-neutral-800">선 예매</span>
+              <span class="text-zinc-600">{{ bookingEarly }}</span>
+            </div>
+            <div class="flex">
+              <span class="w-24 font-bold text-neutral-800">장 소</span>
+              <span class="text-zinc-600">{{ venue }}</span>
+            </div>
+            <div class="flex">
+              <span class="w-24 font-bold text-neutral-800">일반 예매</span>
+              <span class="text-zinc-600">{{ bookingNormal }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  defineProps({
+    posterUrl: String,
+    title: String,
+    genre: String,
+    period: String,
+    isOngoing: Boolean,
+    score: Number,
+    tags: Array,
+    duration: String,
+    ageLimit: String,
+    venue: String,
+    price: String,
+    bookingEarly: String,
+    bookingNormal: String
+  })
+  </script>
+  
+  <style scoped>
+  /* 필요시 추가 스타일 가능 */
+  </style>
+  

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -11,6 +11,7 @@ import SignupSuccess from "../user/SignupSuccess.vue";
 import EventsRegister from "../events/Register.vue";
 import EmailVerification from "../user/EmailVerification.vue";
 import EventShowMore from "../events/EventShowMore.vue";
+import Detail from "../events/Detail.vue";
 
 const routes = [
     {path: "/", component: Main},
@@ -25,6 +26,7 @@ const routes = [
     {path: '/emailverify', name: EmailVerification, component: EmailVerification },
     {path: "/events/register", component: EventsRegister},
     {path: "/events", name: 'EventShowMore', component: EventShowMore},
+    {path: "/events/:id", name: 'Detail', component: Detail, props: true},
 ]
 
 const router = createRouter({


### PR DESCRIPTION
## #️⃣ Issue Number
#63 상단의 간단정보 헤더, 탭

## 📝 요약(Summary)
 상단의 간단정보 헤더, 탭을 구현

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 파일 혹은 폴더명 수정

## 💬 공유사항 to 리뷰어

일단은 데이터를 코드 안에 구현해놨는데 추후에 JSON 형식으로 추가하도록 하겠습니다

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.