### PR TITLE
feat: 공연/전시의 상세페이지 하단 구현 (#65)

### DIFF
--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -1,0 +1,162 @@
+{
+    "events": [
+      {
+        "id": 1,
+        "title": "꽃의 비밀",
+        "genre": "연극",
+        "posterUrl": "/path/to/poster.jpg",
+        "period": "2025.02.08 ~ 2025.05.11",
+        "isOngoing": true,
+        "score": 9.7,
+        "duration": "120분",
+        "ageLimit": "8세 이상",
+        "venue": "원더아트센터 박스홀",
+        "price": "VIP석 77,000원 | R석 66,000원 | S석 55,000원",
+        "bookingEarly": "2025.12.22 ~ 2025.01.14",
+        "bookingNormal": "2025.01.15 ~ 2025.05.10",
+        "cast": [
+          { "name": "김주연", "role": "햄릿 역" },
+          { "name": "박연기", "role": "오필리어 역" },
+          { "name": "정배우", "role": "클로디어스 역" }
+        ],
+        "description": "셰익스피어의 희극 작품을 재해석한 〈꽃의 비밀〉은 인간 내면의 욕망과 사랑에 대한 이야기를 담고 있습니다.",
+        "guidelines": [
+          "8세 이상 관람가 (미취학 아동 입장 불가)",
+          "공연 시작 후에는 입장이 제한됩니다.",
+          "공연장 내 음식물 반입 및 사진/영상 촬영은 금지됩니다."
+        ],
+        "detailImage": "/path/to/detail-image.jpg"
+      },
+      {
+        "id": 2,
+        "title": "한 여름 밤의 꿈",
+        "genre": "연극",
+        "posterUrl": "/path/to/poster2.jpg",
+        "period": "2025.03.01 ~ 2025.06.01",
+        "isOngoing": false,
+        "score": 8.9,
+        "duration": "100분",
+        "ageLimit": "12세 이상",
+        "venue": "예술의전당",
+        "price": "VIP석 80,000원 | R석 70,000원 | S석 50,000원",
+        "bookingEarly": "2025.01.01 ~ 2025.01.15",
+        "bookingNormal": "2025.01.16 ~ 2025.06.01",
+        "cast": [
+          { "name": "이주영", "role": "피터팬 역" },
+          { "name": "박미영", "role": "티틀리 역" },
+          { "name": "김서준", "role": "다이아몬드 역" }
+        ],
+        "description": "셰익스피어의 고전 연극을 현대적인 감각으로 재해석한 작품입니다.",
+        "guidelines": [
+          "12세 이상 관람가",
+          "공연 시작 후에는 입장이 제한됩니다."
+        ],
+        "detailImage": "/path/to/detail-image2.jpg"
+      },
+      
+      {
+        "id": 3,
+        "title": "겨울왕국",
+        "genre": "뮤지컬",
+        "posterUrl": "/path/to/poster.jpg",
+        "period": "2025.02.01 ~ 2025.04.01",
+        "isOngoing": true,
+        "score": 9.8,
+        "duration": "150분",
+        "ageLimit": "5세 이상",
+        "venue": "세종문화회관",
+        "price": "VIP석 120,000원 | R석 100,000원 | S석 80,000원",
+        "bookingEarly": "2024.12.15 ~ 2025.01.10",
+        "bookingNormal": "2025.01.11 ~ 2025.04.01",
+        "cast": [
+          { "name": "김소연", "role": "엘사 역" },
+          { "name": "박지훈", "role": "안나 역" },
+          { "name": "이상엽", "role": "크리스토프 역" }
+        ],
+        "description": "디즈니의 유명 뮤지컬 '겨울왕국'을 서울에서 만나볼 수 있는 기회입니다.",
+        "guidelines": [
+          "5세 이상 관람가",
+          "공연 시작 후에는 입장이 제한됩니다."
+        ],
+        "detailImage": "/path/to/detail-image3.jpg"
+      },
+      {
+        "id": 4,
+        "title": "맘마미아",
+        "genre": "뮤지컬",
+        "posterUrl": "/path/to/poster4.jpg",
+        "period": "2025.04.01 ~ 2025.06.30",
+        "isOngoing": true,
+        "score": 9.5,
+        "duration": "130분",
+        "ageLimit": "10세 이상",
+        "venue": "블루스퀘어",
+        "price": "VIP석 90,000원 | R석 70,000원 | S석 50,000원",
+        "bookingEarly": "2025.01.10 ~ 2025.01.25",
+        "bookingNormal": "2025.01.26 ~ 2025.06.30",
+        "cast": [
+          { "name": "김연수", "role": "소피 역" },
+          { "name": "윤세라", "role": "다나 역" },
+          { "name": "장재영", "role": "하비 역" }
+        ],
+        "description": "'맘마미아'는 ABBA의 히트곡을 모은 뮤지컬로, 전 세계적으로 인기 있는 공연입니다.",
+        "guidelines": [
+          "10세 이상 관람가",
+          "공연 시작 후에는 입장이 제한됩니다."
+        ],
+        "detailImage": "/path/to/detail-image4.jpg"
+      },
+  
+      {
+        "id": 5,
+        "title": "K-POP LIVE",
+        "genre": "콘서트",
+        "posterUrl": "/path/to/poster5.jpg",
+        "period": "2025.03.01 ~ 2025.03.30",
+        "isOngoing": true,
+        "score": 9.6,
+        "duration": "180분",
+        "ageLimit": "15세 이상",
+        "venue": "올림픽공원",
+        "price": "VIP석 150,000원 | R석 120,000원 | S석 90,000원",
+        "bookingEarly": "2025.01.15 ~ 2025.02.01",
+        "bookingNormal": "2025.02.02 ~ 2025.03.30",
+        "cast": [
+          { "name": "BTS", "role": "메인 아티스트" },
+          { "name": "블랙핑크", "role": "서브 아티스트" },
+          { "name": "아이유", "role": "특별 게스트" }
+        ],
+        "description": "K-POP의 최신 히트곡들을 모은 대규모 콘서트.",
+        "guidelines": [
+          "15세 이상 관람가",
+          "공연 시작 후에는 입장이 제한됩니다."
+        ],
+        "detailImage": "/path/to/detail-image5.jpg"
+      },
+      {
+        "id": 6,
+        "title": "소녀시대 콘서트",
+        "genre": "콘서트",
+        "posterUrl": "/path/to/poster6.jpg",
+        "period": "2025.04.10 ~ 2025.05.10",
+        "isOngoing": false,
+        "score": 9.3,
+        "duration": "120분",
+        "ageLimit": "12세 이상",
+        "venue": "서울 잠실 실내체육관",
+        "price": "VIP석 130,000원 | R석 100,000원 | S석 80,000원",
+        "bookingEarly": "2025.01.20 ~ 2025.02.05",
+        "bookingNormal": "2025.02.06 ~ 2025.05.10",
+        "cast": [
+          { "name": "소녀시대", "role": "주요 아티스트" }
+        ],
+        "description": "소녀시대의 최신 곡과 클래식 히트곡들을 함께 즐길 수 있는 콘서트.",
+        "guidelines": [
+          "12세 이상 관람가",
+          "공연 시작 후에는 입장이 제한됩니다."
+        ],
+        "detailImage": "/path/to/detail-image6.jpg"
+      }
+    ]
+  }
+  

--- a/src/events/Detail.vue
+++ b/src/events/Detail.vue
@@ -1,10 +1,17 @@
 <!-- src/events/Detail.vue -->
 <template>
     <div class="pt-10 px-20">
+      <!-- 상단 Header와 탭 부분 -->
       <EventHeaderInfo v-bind="event" />
+
+      <div class="mb-8">
       <EventTabs v-model:tab="selectedTab" />
-      <!-- <EventDetailContent v-if="selectedTab === '상세 정보'" /> -->
-      <!-- 추가: 추천, 게시판, 한줄평 영역도 나중에 연결 가능 -->
+    </div>
+    
+      <!-- 상세 정보 탭 -->
+      <div v-if="selectedTab === '상세 정보'">
+        <EventDetail :event="event" />
+      </div>
     </div>
   </template>
   
@@ -13,32 +20,30 @@
   import { ref, computed } from 'vue'
   import EventHeaderInfo from './EventHeaderInfo.vue'
   import EventTabs from './EventDetailTab.vue'
+  import EventDetail from './EventDetail.vue'
+  import eventsData from '../assets/data/events.json'
   
   // 1. 라우터에서 id 가져오기
   const route = useRoute()
   const id = Number(route.params.id)
   
-  // 2. 임시 데이터 (추후 API 대체 가능)
-  const eventList = [
-    {
-      id: 1,
-      title: '알라딘',
-      genre: '뮤지컬',
-      posterUrl: '/images/aladdin.jpg',
-      period: '2025.02.08 ~ 2025.05.11',
-      isOngoing: true,
-      score: 9.5,
-      duration: '150분',
-      ageLimit: '8세 이상',
-      venue: '샤롯데씨어터',
-      price: 'VIP석 110,000원 | R석 99,000원 | S석 77,000원',
-      bookingEarly: '2024.12.22 ~ 2025.01.10',
-      bookingNormal: '2025.01.11 ~ 2025.05.10'
-    },
-    // ... 다른 이벤트들
-  ]
+  // 2. JSON에서 이벤트 찾기
+  const event = computed(() => {
+    return eventsData.events.find(e => e.id === id)
+  })
   
-  const event = computed(() => eventList.find(e => e.id === id))
+  // 3. 탭 상태 관리
   const selectedTab = ref('상세 정보')
   </script>
+  
+  <style scoped>
+  /* 필요시 추가 스타일 */
+  .pt-10 {
+    padding-top: 2.5rem; /* 상단 여백 */
+  }
+  .px-20 {
+    padding-left: 5rem;
+    padding-right: 5rem;
+  }
+  </style>
   

--- a/src/events/EventDetail.vue
+++ b/src/events/EventDetail.vue
@@ -1,0 +1,89 @@
+<template>
+    <div class="text-gray-800 text-sm space-y-10 max-w-[1320px] mx-auto">
+      <!-- 예매 정보 -->
+      <section>
+        <h2 class="text-lg font-bold mb-3">예매 정보</h2>
+        <div class="flex flex-col md:flex-row gap-4">
+          <div class="bg-red-50 p-4 rounded-md flex-1">
+            <p class="font-semibold">선예매</p>
+            <p>{{ event.bookingEarly }}</p>
+            <div class="mt-1">
+              <span class="inline-block bg-red-400 text-white px-2 py-0.5 rounded text-xs">선예매중</span>
+            </div>
+          </div>
+          <div class="bg-green-50 p-4 rounded-md flex-1">
+            <p class="font-semibold">일반예매</p>
+            <p>{{ event.bookingNormal }}</p>
+            <div class="mt-1 flex flex-wrap gap-1">
+              <span class="bg-red-400 text-white px-2 py-0.5 rounded text-xs">선예매</span>
+              <span class="bg-blue-400 text-white px-2 py-0.5 rounded text-xs">예스24</span>
+              <span class="bg-green-400 text-white px-2 py-0.5 rounded text-xs">티켓링크</span>
+            </div>
+          </div>
+        </div>
+        <hr class="mt-6 border-gray-300" />
+      </section>
+  
+      <!-- 출연진 -->
+      <section>
+        <h2 class="text-lg font-bold mb-3">출연진</h2>
+        <div class="flex flex-wrap gap-4">
+          <div
+            v-for="member in event.cast"
+            :key="member.name"
+            class="bg-gray-100 px-4 py-2 rounded-md"
+          >
+            <p class="font-semibold">{{ member.name }}</p>
+            <p class="text-sm text-gray-600">{{ member.role }}</p>
+          </div>
+        </div>
+        <hr class="mt-6 border-gray-300" />
+      </section>
+  
+      <!-- 공연 소개 -->
+      <section>
+        <h2 class="text-lg font-bold mb-3">공연 소개</h2>
+        <p class="leading-relaxed whitespace-pre-line">
+          {{ event.description }}
+          <br /><br />
+          {{ event.venue }}에서 진행되는 이번 공연은 중학생 이상 관람 가능한 작품으로,<br />
+          소비자와 자신의 역할을 잇는 배우들의 무대입니다.<br />
+          특유의 복식, 공정성, 정정당당 등 실력파 배우들의 열연이 이번 작품의 큰 highlight입니다.<br />
+          {{ event.duration }} 동안 펼쳐지는 감동의 무대, &lt;{{ event.title }}&gt;과 함께하세요.
+        </p>
+        <hr class="mt-6 border-gray-300" />
+      </section>
+  
+      <!-- 관람 안내 -->
+      <section>
+        <h2 class="text-lg font-bold mb-3">관람 안내</h2>
+        <ul class="list-disc list-inside text-gray-700">
+          <li v-for="(rule, index) in event.guidelines" :key="index">
+            {{ rule }}
+          </li>
+        </ul>
+        <hr class="mt-6 border-gray-300" />
+      </section>
+  
+      <!-- 상세 이미지 -->
+      <section>
+        <h2 class="text-lg font-bold mb-3">상세 정보 (예매 사이트 이미지)</h2>
+        <div class="border rounded-lg bg-gray-50 flex items-center justify-center h-64">
+          <img
+            v-if="event.detailImage"
+            :src="event.detailImage"
+            alt="상세 이미지"
+            class="object-contain max-h-full"
+          />
+          <p v-else class="text-sm text-gray-400">이 영역에 예매 사이트에서 가져온 상세 정보 이미지가 배치됩니다</p>
+        </div>
+      </section>
+    </div>
+  </template>
+  
+  <script setup>
+  defineProps({
+    event: Object
+  })
+  </script>
+  

--- a/src/events/EventDetailTab.vue
+++ b/src/events/EventDetailTab.vue
@@ -1,13 +1,13 @@
 <template>
-    <div class="w-[1320px] bg-white flex relative">
+    <div class="w-[1320px] bg-white flex relative mx-auto">
       <div
         v-for="tabName in tabs"  
         :key="tabName"
         class="w-28 h-14 bg-white cursor-pointer flex items-center justify-center"
         @click="$emit('update:tab', tabName)" 
-        >
+      >
         <div
-          :class="[
+          :class="[ 
             'text-center text-xl font-[Inter]',
             tabName === tab  
               ? 'text-violet-600 font-extrabold'
@@ -46,5 +46,6 @@
   </script>
   
   <style scoped>
-
+  /* 추가 스타일 필요 시 여기에 작성 */
   </style>
+  


### PR DESCRIPTION
## #️⃣ Issue Number
#65 공연/전시의 상세 페이지 > 하단 구현

## 📝 요약(Summary)
예매 정보, 출연진, 공연 소개,  관람 안내, 상세정보 추가해서 상세 페이지 구현

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)


## 💬 공유사항 to 리뷰어
가장 하단의 사진 더보기 버튼은 추후에 수정하여 기능 구현 예정

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.