### PR TITLE
feat: 상세정보 페이지 가장 하단의 이미지 더보기 구현, 구조 수정 (#70)

### DIFF
--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -1,162 +1,180 @@
 {
-    "events": [
-      {
-        "id": 1,
-        "title": "꽃의 비밀",
-        "genre": "연극",
-        "posterUrl": "/path/to/poster.jpg",
-        "period": "2025.02.08 ~ 2025.05.11",
-        "isOngoing": true,
-        "score": 9.7,
-        "duration": "120분",
-        "ageLimit": "8세 이상",
-        "venue": "원더아트센터 박스홀",
-        "price": "VIP석 77,000원 | R석 66,000원 | S석 55,000원",
-        "bookingEarly": "2025.12.22 ~ 2025.01.14",
-        "bookingNormal": "2025.01.15 ~ 2025.05.10",
-        "cast": [
-          { "name": "김주연", "role": "햄릿 역" },
-          { "name": "박연기", "role": "오필리어 역" },
-          { "name": "정배우", "role": "클로디어스 역" }
-        ],
-        "description": "셰익스피어의 희극 작품을 재해석한 〈꽃의 비밀〉은 인간 내면의 욕망과 사랑에 대한 이야기를 담고 있습니다.",
-        "guidelines": [
-          "8세 이상 관람가 (미취학 아동 입장 불가)",
-          "공연 시작 후에는 입장이 제한됩니다.",
-          "공연장 내 음식물 반입 및 사진/영상 촬영은 금지됩니다."
-        ],
-        "detailImage": "/path/to/detail-image.jpg"
+  "events": [
+    {
+      "id": 1,
+      "title": "꽃의 비밀",
+      "genre": "연극",
+      "posterUrl": "/path/to/poster.jpg",
+      "period": "2025.02.08 ~ 2025.05.11",
+      "isOngoing": true,
+      "score": 9.7,
+      "duration": "120분",
+      "ageLimit": "8세 이상",
+      "venue": "원더아트센터 박스홀",
+      "price": "VIP석 77,000원 | R석 66,000원 | S석 55,000원",
+      "bookingEarly": {
+        "period": "2025.12.22 ~ 2025.01.14",
+        "vendors": ["공식홈", "인터파크"]
       },
-      {
-        "id": 2,
-        "title": "한 여름 밤의 꿈",
-        "genre": "연극",
-        "posterUrl": "/path/to/poster2.jpg",
-        "period": "2025.03.01 ~ 2025.06.01",
-        "isOngoing": false,
-        "score": 8.9,
-        "duration": "100분",
-        "ageLimit": "12세 이상",
-        "venue": "예술의전당",
-        "price": "VIP석 80,000원 | R석 70,000원 | S석 50,000원",
-        "bookingEarly": "2025.01.01 ~ 2025.01.15",
-        "bookingNormal": "2025.01.16 ~ 2025.06.01",
-        "cast": [
-          { "name": "이주영", "role": "피터팬 역" },
-          { "name": "박미영", "role": "티틀리 역" },
-          { "name": "김서준", "role": "다이아몬드 역" }
-        ],
-        "description": "셰익스피어의 고전 연극을 현대적인 감각으로 재해석한 작품입니다.",
-        "guidelines": [
-          "12세 이상 관람가",
-          "공연 시작 후에는 입장이 제한됩니다."
-        ],
-        "detailImage": "/path/to/detail-image2.jpg"
+      "bookingNormal": {
+        "period": "2025.01.15 ~ 2025.05.10",
+        "vendors": ["공식홈", "인터파크", "예스24", "티켓링크"]
       },
-      
-      {
-        "id": 3,
-        "title": "겨울왕국",
-        "genre": "뮤지컬",
-        "posterUrl": "/path/to/poster.jpg",
-        "period": "2025.02.01 ~ 2025.04.01",
-        "isOngoing": true,
-        "score": 9.8,
-        "duration": "150분",
-        "ageLimit": "5세 이상",
-        "venue": "세종문화회관",
-        "price": "VIP석 120,000원 | R석 100,000원 | S석 80,000원",
-        "bookingEarly": "2024.12.15 ~ 2025.01.10",
-        "bookingNormal": "2025.01.11 ~ 2025.04.01",
-        "cast": [
-          { "name": "김소연", "role": "엘사 역" },
-          { "name": "박지훈", "role": "안나 역" },
-          { "name": "이상엽", "role": "크리스토프 역" }
-        ],
-        "description": "디즈니의 유명 뮤지컬 '겨울왕국'을 서울에서 만나볼 수 있는 기회입니다.",
-        "guidelines": [
-          "5세 이상 관람가",
-          "공연 시작 후에는 입장이 제한됩니다."
-        ],
-        "detailImage": "/path/to/detail-image3.jpg"
+      "cast": [
+        { "name": "김주연", "role": "햄릿 역" },
+        { "name": "박연기", "role": "오필리어 역" },
+        { "name": "정배우", "role": "클로디어스 역" }
+      ],
+      "description": "셰익스피어의 희극 작품을 재해석한 〈꽃의 비밀〉은 인간 내면의 욕망과 사랑에 대한 이야기를 담고 있습니다.",
+      "guidelines": [
+        "8세 이상 관람가 (미취학 아동 입장 불가)",
+        "공연 시작 후에는 입장이 제한됩니다.",
+        "공연장 내 음식물 반입 및 사진/영상 촬영은 금지됩니다."
+      ],
+      "detailImage": "/path/to/detail-image.jpg"
+    },
+    {
+      "id": 2,
+      "title": "한 여름 밤의 꿈",
+      "genre": "연극",
+      "posterUrl": "/path/to/poster2.jpg",
+      "period": "2025.03.01 ~ 2025.06.01",
+      "isOngoing": false,
+      "score": 8.9,
+      "duration": "100분",
+      "ageLimit": "12세 이상",
+      "venue": "예술의전당",
+      "price": "VIP석 80,000원 | R석 70,000원 | S석 50,000원",
+      "bookingEarly": {
+        "period": "2025.12.22 ~ 2025.01.14",
+        "vendors": ["공식홈", "인터파크"]
       },
-      {
-        "id": 4,
-        "title": "맘마미아",
-        "genre": "뮤지컬",
-        "posterUrl": "/path/to/poster4.jpg",
-        "period": "2025.04.01 ~ 2025.06.30",
-        "isOngoing": true,
-        "score": 9.5,
-        "duration": "130분",
-        "ageLimit": "10세 이상",
-        "venue": "블루스퀘어",
-        "price": "VIP석 90,000원 | R석 70,000원 | S석 50,000원",
-        "bookingEarly": "2025.01.10 ~ 2025.01.25",
-        "bookingNormal": "2025.01.26 ~ 2025.06.30",
-        "cast": [
-          { "name": "김연수", "role": "소피 역" },
-          { "name": "윤세라", "role": "다나 역" },
-          { "name": "장재영", "role": "하비 역" }
-        ],
-        "description": "'맘마미아'는 ABBA의 히트곡을 모은 뮤지컬로, 전 세계적으로 인기 있는 공연입니다.",
-        "guidelines": [
-          "10세 이상 관람가",
-          "공연 시작 후에는 입장이 제한됩니다."
-        ],
-        "detailImage": "/path/to/detail-image4.jpg"
+      "bookingNormal": {
+        "period": "2025.01.15 ~ 2025.05.10",
+        "vendors": ["공식홈", "인터파크", "예스24", "티켓링크"]
       },
-  
-      {
-        "id": 5,
-        "title": "K-POP LIVE",
-        "genre": "콘서트",
-        "posterUrl": "/path/to/poster5.jpg",
-        "period": "2025.03.01 ~ 2025.03.30",
-        "isOngoing": true,
-        "score": 9.6,
-        "duration": "180분",
-        "ageLimit": "15세 이상",
-        "venue": "올림픽공원",
-        "price": "VIP석 150,000원 | R석 120,000원 | S석 90,000원",
-        "bookingEarly": "2025.01.15 ~ 2025.02.01",
-        "bookingNormal": "2025.02.02 ~ 2025.03.30",
-        "cast": [
-          { "name": "BTS", "role": "메인 아티스트" },
-          { "name": "블랙핑크", "role": "서브 아티스트" },
-          { "name": "아이유", "role": "특별 게스트" }
-        ],
-        "description": "K-POP의 최신 히트곡들을 모은 대규모 콘서트.",
-        "guidelines": [
-          "15세 이상 관람가",
-          "공연 시작 후에는 입장이 제한됩니다."
-        ],
-        "detailImage": "/path/to/detail-image5.jpg"
+      "cast": [
+        { "name": "이주영", "role": "피터팬 역" },
+        { "name": "박미영", "role": "티틀리 역" },
+        { "name": "김서준", "role": "다이아몬드 역" }
+      ],
+      "description": "셰익스피어의 고전 연극을 현대적인 감각으로 재해석한 작품입니다.",
+      "guidelines": ["12세 이상 관람가", "공연 시작 후에는 입장이 제한됩니다."],
+      "detailImage": "/path/to/detail-image2.jpg"
+    },
+
+    {
+      "id": 3,
+      "title": "겨울왕국",
+      "genre": "뮤지컬",
+      "posterUrl": "/path/to/poster.jpg",
+      "period": "2025.02.01 ~ 2025.04.01",
+      "isOngoing": true,
+      "score": 9.8,
+      "duration": "150분",
+      "ageLimit": "5세 이상",
+      "venue": "세종문화회관",
+      "price": "VIP석 120,000원 | R석 100,000원 | S석 80,000원",
+      "bookingEarly": {
+        "period": "2025.12.22 ~ 2025.01.14",
+        "vendors": ["공식홈", "인터파크"]
       },
-      {
-        "id": 6,
-        "title": "소녀시대 콘서트",
-        "genre": "콘서트",
-        "posterUrl": "/path/to/poster6.jpg",
-        "period": "2025.04.10 ~ 2025.05.10",
-        "isOngoing": false,
-        "score": 9.3,
-        "duration": "120분",
-        "ageLimit": "12세 이상",
-        "venue": "서울 잠실 실내체육관",
-        "price": "VIP석 130,000원 | R석 100,000원 | S석 80,000원",
-        "bookingEarly": "2025.01.20 ~ 2025.02.05",
-        "bookingNormal": "2025.02.06 ~ 2025.05.10",
-        "cast": [
-          { "name": "소녀시대", "role": "주요 아티스트" }
-        ],
-        "description": "소녀시대의 최신 곡과 클래식 히트곡들을 함께 즐길 수 있는 콘서트.",
-        "guidelines": [
-          "12세 이상 관람가",
-          "공연 시작 후에는 입장이 제한됩니다."
-        ],
-        "detailImage": "/path/to/detail-image6.jpg"
-      }
-    ]
-  }
-  
+      "bookingNormal": {
+        "period": "2025.01.15 ~ 2025.05.10",
+        "vendors": ["공식홈", "인터파크", "예스24", "티켓링크"]
+      },
+      "cast": [
+        { "name": "김소연", "role": "엘사 역" },
+        { "name": "박지훈", "role": "안나 역" },
+        { "name": "이상엽", "role": "크리스토프 역" }
+      ],
+      "description": "디즈니의 유명 뮤지컬 '겨울왕국'을 서울에서 만나볼 수 있는 기회입니다.",
+      "guidelines": ["5세 이상 관람가", "공연 시작 후에는 입장이 제한됩니다."],
+      "detailImage": "/path/to/detail-image3.jpg"
+    },
+    {
+      "id": 4,
+      "title": "맘마미아",
+      "genre": "뮤지컬",
+      "posterUrl": "/path/to/poster4.jpg",
+      "period": "2025.04.01 ~ 2025.06.30",
+      "isOngoing": true,
+      "score": 9.5,
+      "duration": "130분",
+      "ageLimit": "10세 이상",
+      "venue": "블루스퀘어",
+      "price": "VIP석 90,000원 | R석 70,000원 | S석 50,000원",
+      "bookingEarly": {
+        "period": "2025.12.22 ~ 2025.01.14",
+        "vendors": ["공식홈", "인터파크"]
+      },
+      "bookingNormal": {
+        "period": "2025.01.15 ~ 2025.05.10",
+        "vendors": ["공식홈", "인터파크", "예스24", "티켓링크"]
+      },
+      "cast": [
+        { "name": "김연수", "role": "소피 역" },
+        { "name": "윤세라", "role": "다나 역" },
+        { "name": "장재영", "role": "하비 역" }
+      ],
+      "description": "'맘마미아'는 ABBA의 히트곡을 모은 뮤지컬로, 전 세계적으로 인기 있는 공연입니다.",
+      "guidelines": ["10세 이상 관람가", "공연 시작 후에는 입장이 제한됩니다."],
+      "detailImage": "/path/to/detail-image4.jpg"
+    },
+
+    {
+      "id": 5,
+      "title": "K-POP LIVE",
+      "genre": "콘서트",
+      "posterUrl": "/path/to/poster5.jpg",
+      "period": "2025.03.01 ~ 2025.03.30",
+      "isOngoing": true,
+      "score": 9.6,
+      "duration": "180분",
+      "ageLimit": "15세 이상",
+      "venue": "올림픽공원",
+      "price": "VIP석 150,000원 | R석 120,000원 | S석 90,000원",
+      "bookingEarly": {
+        "period": "2025.12.22 ~ 2025.01.14",
+        "vendors": ["공식홈", "인터파크"]
+      },
+      "bookingNormal": {
+        "period": "2025.01.15 ~ 2025.05.10",
+        "vendors": ["공식홈", "인터파크", "예스24", "티켓링크"]
+      },
+      "cast": [
+        { "name": "BTS", "role": "메인 아티스트" },
+        { "name": "블랙핑크", "role": "서브 아티스트" },
+        { "name": "아이유", "role": "특별 게스트" }
+      ],
+      "description": "K-POP의 최신 히트곡들을 모은 대규모 콘서트.",
+      "guidelines": ["15세 이상 관람가", "공연 시작 후에는 입장이 제한됩니다."],
+      "detailImage": "/path/to/detail-image5.jpg"
+    },
+    {
+      "id": 6,
+      "title": "소녀시대 콘서트",
+      "genre": "콘서트",
+      "posterUrl": "/path/to/poster6.jpg",
+      "period": "2025.04.10 ~ 2025.05.10",
+      "isOngoing": false,
+      "score": 9.3,
+      "duration": "120분",
+      "ageLimit": "12세 이상",
+      "venue": "서울 잠실 실내체육관",
+      "price": "VIP석 130,000원 | R석 100,000원 | S석 80,000원",
+      "bookingEarly": {
+        "period": "2025.12.22 ~ 2025.01.14",
+        "vendors": ["공식홈", "인터파크"]
+      },
+      "bookingNormal": {
+        "period": "2025.01.15 ~ 2025.05.10",
+        "vendors": ["공식홈", "인터파크", "예스24", "티켓링크"]
+      },
+      "cast": [{ "name": "소녀시대", "role": "주요 아티스트" }],
+      "description": "소녀시대의 최신 곡과 클래식 히트곡들을 함께 즐길 수 있는 콘서트.",
+      "guidelines": ["12세 이상 관람가", "공연 시작 후에는 입장이 제한됩니다."],
+      "detailImage": "/path/to/detail-image6.jpg"
+    }
+  ]
+}

--- a/src/events/Detail.vue
+++ b/src/events/Detail.vue
@@ -1,23 +1,27 @@
-<!-- src/events/Detail.vue -->
 <template>
-    <div class="pt-10 px-20">
+    <div class="pt-10 px-20" v-if="event">
       <!-- 상단 Header와 탭 부분 -->
-      <EventHeaderInfo v-bind="event" />
-
+      <EventHeaderInfo :event="event" />
+  
       <div class="mb-8">
-      <EventTabs v-model:tab="selectedTab" />
-    </div>
-    
+        <EventTabs v-model:tab="selectedTab" />
+      </div>
+  
       <!-- 상세 정보 탭 -->
       <div v-if="selectedTab === '상세 정보'">
         <EventDetail :event="event" />
       </div>
     </div>
+  
+    <div v-else class="text-center text-gray-500 pt-20">
+      로딩 중입니다...
+    </div>
   </template>
+  
   
   <script setup>
   import { useRoute } from 'vue-router'
-  import { ref, computed } from 'vue'
+  import { ref, onMounted } from 'vue'
   import EventHeaderInfo from './EventHeaderInfo.vue'
   import EventTabs from './EventDetailTab.vue'
   import EventDetail from './EventDetail.vue'
@@ -28,9 +32,11 @@
   const id = Number(route.params.id)
   
   // 2. JSON에서 이벤트 찾기
-  const event = computed(() => {
-    return eventsData.events.find(e => e.id === id)
-  })
+  const event = ref(null)
+  onMounted(() => {
+  const found = eventsData.events.find(e => e.id === id)
+  event.value = found
+})
   
   // 3. 탭 상태 관리
   const selectedTab = ref('상세 정보')

--- a/src/events/EventDetail.vue
+++ b/src/events/EventDetail.vue
@@ -1,89 +1,142 @@
 <template>
-    <div class="text-gray-800 text-sm space-y-10 max-w-[1320px] mx-auto">
-      <!-- 예매 정보 -->
-      <section>
-        <h2 class="text-lg font-bold mb-3">예매 정보</h2>
-        <div class="flex flex-col md:flex-row gap-4">
-          <div class="bg-red-50 p-4 rounded-md flex-1">
-            <p class="font-semibold">선예매</p>
-            <p>{{ event.bookingEarly }}</p>
-            <div class="mt-1">
-              <span class="inline-block bg-red-400 text-white px-2 py-0.5 rounded text-xs">선예매중</span>
-            </div>
-          </div>
-          <div class="bg-green-50 p-4 rounded-md flex-1">
-            <p class="font-semibold">일반예매</p>
-            <p>{{ event.bookingNormal }}</p>
-            <div class="mt-1 flex flex-wrap gap-1">
-              <span class="bg-red-400 text-white px-2 py-0.5 rounded text-xs">선예매</span>
-              <span class="bg-blue-400 text-white px-2 py-0.5 rounded text-xs">예스24</span>
-              <span class="bg-green-400 text-white px-2 py-0.5 rounded text-xs">티켓링크</span>
-            </div>
+  <div class="text-gray-800 text-sm space-y-10 max-w-[1320px] mx-auto">
+    <!-- 예매 정보 -->
+    <section>
+      <h2 class="text-lg font-bold mb-3">예매 정보</h2>
+      <div class="flex flex-col md:flex-row gap-4">
+        <!-- 선예매 -->
+        <div class="bg-purple-50 p-4 rounded-md flex-1">
+          <p class="font-semibold">선예매</p>
+          <p>선예매 {{ event.bookingEarly.period }}</p>
+          <div class="mt-1 flex flex-wrap gap-1">
+            <span
+              v-for="vendor in event.bookingEarly.vendors"
+              :key="vendor"
+              class="px-2 py-0.5 rounded text-xs text-white"
+              :class="getVendorClass(vendor)"
+            >
+              {{ vendor }}
+            </span>
           </div>
         </div>
-        <hr class="mt-6 border-gray-300" />
-      </section>
-  
-      <!-- 출연진 -->
-      <section>
-        <h2 class="text-lg font-bold mb-3">출연진</h2>
-        <div class="flex flex-wrap gap-4">
-          <div
-            v-for="member in event.cast"
-            :key="member.name"
-            class="bg-gray-100 px-4 py-2 rounded-md"
-          >
-            <p class="font-semibold">{{ member.name }}</p>
-            <p class="text-sm text-gray-600">{{ member.role }}</p>
+
+        <!-- 일반예매 -->
+        <div class="bg-green-50 p-4 rounded-md flex-1">
+          <p class="font-semibold">일반예매</p>
+          <p>일반 예매 {{ event.bookingNormal.period }}</p>
+          <div class="mt-1 flex flex-wrap gap-1">
+            <span
+              v-for="vendor in event.bookingNormal.vendors"
+              :key="vendor"
+              class="px-2 py-0.5 rounded text-xs text-white"
+              :class="getVendorClass(vendor)"
+            >
+              {{ vendor }}
+            </span>
           </div>
         </div>
-        <hr class="mt-6 border-gray-300" />
-      </section>
-  
-      <!-- 공연 소개 -->
-      <section>
-        <h2 class="text-lg font-bold mb-3">공연 소개</h2>
-        <p class="leading-relaxed whitespace-pre-line">
-          {{ event.description }}
-          <br /><br />
-          {{ event.venue }}에서 진행되는 이번 공연은 중학생 이상 관람 가능한 작품으로,<br />
-          소비자와 자신의 역할을 잇는 배우들의 무대입니다.<br />
-          특유의 복식, 공정성, 정정당당 등 실력파 배우들의 열연이 이번 작품의 큰 highlight입니다.<br />
-          {{ event.duration }} 동안 펼쳐지는 감동의 무대, &lt;{{ event.title }}&gt;과 함께하세요.
+      </div>
+      <hr class="mt-6 border-gray-300" />
+    </section>
+
+    <!-- 출연진 -->
+    <section>
+      <h2 class="text-lg font-bold mb-3">출연진</h2>
+      <div class="flex flex-wrap gap-4">
+        <div
+          v-for="member in event.cast"
+          :key="member.name"
+          class="bg-gray-100 px-4 py-2 rounded-md"
+        >
+          <p class="font-semibold">{{ member.name }}</p>
+          <p class="text-sm text-gray-600">{{ member.role }}</p>
+        </div>
+      </div>
+      <hr class="mt-6 border-gray-300" />
+    </section>
+
+    <!-- 공연 소개 -->
+    <section>
+      <h2 class="text-lg font-bold mb-3">공연 소개</h2>
+      <p class="leading-relaxed whitespace-pre-line">
+        {{ event.description }}
+        <br /><br />
+        {{ event.venue }}에서 진행되는 이번 공연은 중학생 이상 관람 가능한
+        작품으로,<br />
+        소비자와 자신의 역할을 잇는 배우들의 무대입니다.<br />
+        특유의 복식, 공정성, 정정당당 등 실력파 배우들의 열연이 이번 작품의 큰
+        highlight입니다.<br />
+        {{ event.duration }} 동안 펼쳐지는 감동의 무대, &lt;{{
+          event.title
+        }}&gt;과 함께하세요.
+      </p>
+      <hr class="mt-6 border-gray-300" />
+    </section>
+
+    <!-- 관람 안내 -->
+    <section>
+      <h2 class="text-lg font-bold mb-3">관람 안내</h2>
+      <ul class="list-disc list-inside text-gray-700">
+        <li v-for="(rule, index) in event.guidelines" :key="index">
+          {{ rule }}
+        </li>
+      </ul>
+      <hr class="mt-6 border-gray-300" />
+    </section>
+
+    <!-- 상세 이미지 -->
+    <section>
+      <h2 class="text-lg font-bold mb-3">상세 정보 (예매 사이트 이미지)</h2>
+      <div
+        class="border rounded-lg bg-gray-50 overflow-hidden transition-all duration-500"
+        :class="{ 'max-h-[600px]': !showFullImage }"
+      >
+        <img
+          v-if="event.detailImage"
+          :src="event.detailImage"
+          alt="상세 이미지"
+          class="w-full object-contain"
+        />
+        <p v-else class="text-sm text-gray-400 text-center py-10">
+          이 영역에 예매 사이트에서 가져온 상세 정보 이미지가 배치됩니다
         </p>
-        <hr class="mt-6 border-gray-300" />
-      </section>
-  
-      <!-- 관람 안내 -->
-      <section>
-        <h2 class="text-lg font-bold mb-3">관람 안내</h2>
-        <ul class="list-disc list-inside text-gray-700">
-          <li v-for="(rule, index) in event.guidelines" :key="index">
-            {{ rule }}
-          </li>
-        </ul>
-        <hr class="mt-6 border-gray-300" />
-      </section>
-  
-      <!-- 상세 이미지 -->
-      <section>
-        <h2 class="text-lg font-bold mb-3">상세 정보 (예매 사이트 이미지)</h2>
-        <div class="border rounded-lg bg-gray-50 flex items-center justify-center h-64">
-          <img
-            v-if="event.detailImage"
-            :src="event.detailImage"
-            alt="상세 이미지"
-            class="object-contain max-h-full"
-          />
-          <p v-else class="text-sm text-gray-400">이 영역에 예매 사이트에서 가져온 상세 정보 이미지가 배치됩니다</p>
-        </div>
-      </section>
-    </div>
-  </template>
-  
-  <script setup>
-  defineProps({
-    event: Object
-  })
-  </script>
-  
+      </div>
+
+      <div v-if="event.detailImage" class="text-center mt-3">
+        <button
+          @click="showFullImage = !showFullImage"
+          class="text-sm text-violet-600 underline hover:font-semibold transition"
+        >
+          {{ showFullImage ? "접기" : "더보기" }}
+        </button>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+defineProps({
+  event: Object,
+});
+
+const showFullImage = ref(false);
+
+const getVendorClass = (vendor) => {
+  switch (vendor) {
+    case '인터파크':
+      return 'bg-red-400'
+    case '예스24':
+      return 'bg-blue-500'
+    case '티켓링크':
+      return 'bg-green-500'
+    case '공식홈':
+    case '공식홈페이지':
+      return 'bg-black'
+    default:
+      return 'bg-gray-400'
+  }
+}
+
+</script>

--- a/src/events/EventHeaderInfo.vue
+++ b/src/events/EventHeaderInfo.vue
@@ -2,25 +2,23 @@
     <div class="w-[1320px] h-80 relative bg-violet-50 rounded-xl mx-auto">
       <!-- 포스터 이미지 박스 -->
       <div class="w-44 h-56 absolute left-[48px] top-[67px] bg-amber-300 rounded-[10px] flex items-center justify-center">
-        <!-- 포스터 이미지 실제로 들어갈 곳 -->
-        <img :src="posterUrl" alt="포스터" class="w-24 h-36 object-cover" />
+        <img :src="event.posterUrl" alt="포스터" class="w-24 h-36 object-cover" />
       </div>
   
       <!-- 공연 정보 텍스트 -->
       <div class="absolute left-[255px] top-[72px]">
         <div class="flex items-center space-x-2">
-          <span class="text-2xl font-bold text-neutral-800">{{ genre }}</span>
-          <span class="text-2xl font-bold text-neutral-800">{{ title }}</span>
+          <span class="text-2xl font-bold text-neutral-800">{{ event.genre }}</span>
+          <span class="text-2xl font-bold text-neutral-800">{{ event.title }}</span>
         </div>
   
-        <!-- 날짜 & 진행 상태 -->
+        <!-- 날짜 & 상태 -->
         <div class="flex items-center space-x-2 mt-2">
-          <span class="text-sm text-zinc-600">{{ period }}</span>
-          <span v-if="isOngoing" class="px-2 py-0.5 text-sm text-white bg-violet-400 rounded-full">진행중</span>
-          <span v-if="score" class="flex items-center text-yellow-500 text-sm font-semibold">
-            ⭐ {{ score }}
+          <span class="text-sm text-zinc-600">{{ event.period }}</span>
+          <span v-if="event.isOngoing" class="px-2 py-0.5 text-sm text-white bg-violet-400 rounded-full">진행중</span>
+          <span v-if="event.score" class="flex items-center text-yellow-500 text-sm font-semibold">
+            ⭐ {{ event.score }}
           </span>
-          <!-- 알림 아이콘 자리 (하트, 벨 등) -->
           <span class="text-purple-500">❤️</span>
           <span class="text-purple-500">🔔</span>
         </div>
@@ -30,27 +28,27 @@
           <div class="grid grid-cols-2 gap-y-2 gap-x-10 text-sm">
             <div class="flex">
               <span class="w-24 font-bold text-neutral-800">공연 시간</span>
-              <span class="text-zinc-600">{{ duration }}</span>
+              <span class="text-zinc-600">{{ event.duration }}</span>
             </div>
             <div class="flex">
               <span class="w-24 font-bold text-neutral-800">가 격</span>
-              <span class="text-zinc-600">{{ price }}</span>
+              <span class="text-zinc-600">{{ event.price }}</span>
             </div>
             <div class="flex">
               <span class="w-24 font-bold text-neutral-800">관람 연령</span>
-              <span class="text-zinc-600">{{ ageLimit }}</span>
+              <span class="text-zinc-600">{{ event.ageLimit }}</span>
             </div>
             <div class="flex">
               <span class="w-24 font-bold text-neutral-800">선 예매</span>
-              <span class="text-zinc-600">{{ bookingEarly }}</span>
+              <span class="text-zinc-600">{{ event.bookingEarly?.period }}</span>
             </div>
             <div class="flex">
               <span class="w-24 font-bold text-neutral-800">장 소</span>
-              <span class="text-zinc-600">{{ venue }}</span>
+              <span class="text-zinc-600">{{ event.venue }}</span>
             </div>
             <div class="flex">
               <span class="w-24 font-bold text-neutral-800">일반 예매</span>
-              <span class="text-zinc-600">{{ bookingNormal }}</span>
+              <span class="text-zinc-600">{{ event.bookingNormal?.period }}</span>
             </div>
           </div>
         </div>
@@ -60,23 +58,11 @@
   
   <script setup>
   defineProps({
-    posterUrl: String,
-    title: String,
-    genre: String,
-    period: String,
-    isOngoing: Boolean,
-    score: Number,
-    tags: Array,
-    duration: String,
-    ageLimit: String,
-    venue: String,
-    price: String,
-    bookingEarly: String,
-    bookingNormal: String
+    event: Object
   })
   </script>
   
   <style scoped>
-  /* 필요시 추가 스타일 가능 */
+  /* 필요시 추가 스타일 */
   </style>
   


### PR DESCRIPTION
## #️⃣ Issue Number
#70 상세정보 페이지 가장 하단의 이미지 더보기 구현, 구조 수정 

## 📝 요약(Summary)
상세정보 페이지 가장 하단의 이미지 부분에 더보기 버튼 구현, 
상단의 간단정보 헤더 부분의 코드 구조를 JSON 형태의 파일에서 데이터를 받도록 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.