### PR TITLE
feat: 메인페이지에서 공연/전시 더보기 이동 가능하게 수정(#101)

### DIFF
--- a/src/events/EventShowMore.vue
+++ b/src/events/EventShowMore.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
       <!-- 추천 콘텐츠 섹션 -->
-      <Card title="추천 콘텐츠" :cards="combinedCards" />
-  
+       <!-- ✅ 메인에서는 더보기 버튼이 나오고 공연/전시 페이지에서는 더보기 버튼이 없도록 false 처리 -->
+      <Card title="추천 콘텐츠" :cards="combinedCards" :showMoreButton="false" />
       <!-- 카테고리 -->
       <Category />
   

--- a/src/main/Card.vue
+++ b/src/main/Card.vue
@@ -2,7 +2,8 @@
     <div class="card-slider-container">
         <div class="card-slider-header">
             <h2 class="section-title">{{ title }}</h2>
-            <button class="more-btn">더보기</button>
+            <button v-if="showMoreButton" class="more-btn"
+            @click="goToShowMore">더보기</button>
         </div>
 
         <div class="card-slider">
@@ -59,8 +60,13 @@ export default {
         cards: {
             type: Array,
             required: true
-        }
-    },
+        },
+        showMoreButton: {
+    type: Boolean,
+    default: true // 기본은 true (메인에서는 보이게)
+  }
+},
+    
     data() {
         return {
             currentPage: 0,
@@ -116,8 +122,12 @@ export default {
             return {
                 transition: 'transform 0.3s ease, opacity 0.3s ease',
             };
-        }
+        },
+        goToShowMore() {
+     this.$router.push('/events')  // ✅ "/events"로 이동
     }
+},
+    
 };
 </script>
 


### PR DESCRIPTION
## #️⃣ Issue Number
#101 메인페이지에서 공연/전시 더보기 이동 가능하게 코드 수정

## 📝 요약(Summary)
메인페이지에서 공연/전시 더보기 이동이 가능하게 코드 수정 (Card.vue, EventShowMore.vue 수정)

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 주석 추가 및 수정

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.