### PR TITLE
feat: 공연/전시 상세정보 페이지에서 이미지 더보기 부분 수정 (#163)

### DIFF
--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -31,7 +31,12 @@
         "공연 시작 후에는 입장이 제한됩니다.",
         "공연장 내 음식물 반입 및 사진/영상 촬영은 금지됩니다."
       ],
-      "detailImage": "/path/to/detail-image.jpg"
+      "detailImages": [
+        "https://naverbooking-phinf.pstatic.net/20250213_140/1739413655485rXg3D_JPEG/8fd74c96.jpg",
+        "https://naverbooking-phinf.pstatic.net/20250213_110/1739413655644MLHGM_JPEG/2025020516251993.jpg",
+        "https://naverbooking-phinf.pstatic.net/20250213_217/1739413655769KHwYR_JPEG/b9190192.jpg",
+        "https://naverbooking-phinf.pstatic.net/20250305_144/1741139352964yU6YM_JPEG/25%B2%C9%C0%C7%BA%F1%B9%D0_%BB%F3%BC%BC_250228_%281%29.jpg"
+      ]
     },
     {
       "id": 2,
@@ -308,7 +313,11 @@
       },
       "cast": [],
       "description": "우스터미술관 컬렉션으로 만나는 인상주의 대가들의 걸작, 모네에서 미국 인상파로 이어지는 빛의 여정.",
-      "guidelines": ["전체관람가", "전문 장비 촬영 제한", "입장은 관람 종료 1시간 전까지"],
+      "guidelines": [
+        "전체관람가",
+        "전문 장비 촬영 제한",
+        "입장은 관람 종료 1시간 전까지"
+      ],
       "detailImage": "/path/to/detail-image10.jpg"
     },
     {
@@ -342,11 +351,5 @@
       ],
       "detailImage": "/path/to/detail-image11.jpg"
     }
-
-
-
-
-
-
   ]
 }

--- a/src/events/EventDetail.vue
+++ b/src/events/EventDetail.vue
@@ -87,22 +87,42 @@
     <!-- 상세 이미지 -->
     <section>
       <h2 class="text-lg font-bold mb-3">상세 정보 (예매 사이트 이미지)</h2>
+
       <div
         class="border rounded-lg bg-gray-50 overflow-hidden transition-all duration-500"
-        :class="{ 'max-h-[600px]': !showFullImage }"
       >
-        <img
-          v-if="event.detailImage"
-          :src="event.detailImage"
-          alt="상세 이미지"
-          class="w-full object-contain"
-        />
-        <p v-else class="text-sm text-gray-400 text-center py-10">
-          이 영역에 예매 사이트에서 가져온 상세 정보 이미지가 배치됩니다
-        </p>
+        <template v-if="event.detailImages && event.detailImages.length">
+          <!-- 항상 보일 첫 번째 이미지 -->
+          <img
+            :src="event.detailImages[0]"
+            alt="상세 이미지"
+            class="w-full object-contain"
+          />
+
+          <!-- showFullImage가 true일 때만 나머지 이미지 표시 -->
+          <transition-group name="fade" tag="div">
+            <img
+              v-for="(img, i) in event.detailImages.slice(1)"
+              :key="i"
+              v-show="showFullImage"
+              :src="img"
+              alt="상세 이미지 추가"
+              class="w-full object-contain"
+            />
+          </transition-group>
+        </template>
+
+        <template v-else>
+          <p class="text-sm text-gray-400 text-center py-10">
+            이 영역에 예매 사이트에서 가져온 상세 정보 이미지가 배치됩니다
+          </p>
+        </template>
       </div>
 
-      <div v-if="event.detailImage" class="text-center mt-3">
+      <div
+        v-if="event.detailImages && event.detailImages.length > 1"
+        class="text-center mt-3"
+      >
         <button
           @click="showFullImage = !showFullImage"
           class="text-sm text-violet-600 underline hover:font-semibold transition"
@@ -125,18 +145,17 @@ const showFullImage = ref(false);
 
 const getVendorClass = (vendor) => {
   switch (vendor) {
-    case '인터파크':
-      return 'bg-red-400'
-    case '예스24':
-      return 'bg-blue-500'
-    case '티켓링크':
-      return 'bg-green-500'
-    case '공식홈':
-    case '공식홈페이지':
-      return 'bg-black'
+    case "인터파크":
+      return "bg-red-400";
+    case "예스24":
+      return "bg-blue-500";
+    case "티켓링크":
+      return "bg-green-500";
+    case "공식홈":
+    case "공식홈페이지":
+      return "bg-black";
     default:
-      return 'bg-gray-400'
+      return "bg-gray-400";
   }
-}
-
+};
 </script>


### PR DESCRIPTION
## #️⃣ Issue Number
#163 공연/전시 상세정보 페이지에서 이미지 더보기 부분 수정

## 📝 요약(Summary)
공연/전시 상세정보 페이지에서 이미지 더보기 부분 수정, 더보기 버튼은 한번만 눌러도 가능하게, 여러 사진을 넣어도 랜더링 할 수 있도록 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## 💬 공유사항 to 리뷰어

더보기 버튼 디자인은 추후에 수정하도록 하겠습니다~

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.