### PR TITLE
feat: 공연/전시 상세정보 페이지에서 간단정보 헤더 포스터 부분 수정 (#166)

### DIFF
--- a/src/events/EventHeaderInfo.vue
+++ b/src/events/EventHeaderInfo.vue
@@ -1,68 +1,90 @@
 <template>
-    <div class="flex gap-8 h-80 bg-violet-50 rounded-xl mx-auto p-10 ">
-      <!-- 포스터 이미지 박스 -->
-      <div class="w-1/6 h-56 bg-amber-300 rounded-[10px] flex items-center justify-center">
-        <img :src="event.posterUrl" alt="포스터" class="w-24 h-36 object-cover" />
+  <div class="flex gap-8 h-80 bg-violet-50 rounded-xl mx-auto p-10">
+    <!-- 포스터 박스 -->
+    <div class="w-1/6 h-56 rounded-[10px] overflow-hidden shadow">
+      <img
+        :src="event.posterUrl"
+        alt="포스터"
+        class="w-full h-full object-cover"
+      />
+    </div>
+
+    <!-- 공연 정보 텍스트 -->
+    <div class="w-5/6">
+      <div class="flex items-center gap-2">
+        <span class="text-2xl font-bold text-neutral-800">{{
+          event.genre
+        }}</span>
+        <span class="text-2xl font-bold text-neutral-800">{{
+          event.title
+        }}</span>
       </div>
-  
-      <!-- 공연 정보 텍스트 -->
-      <div class="w-5/6">
-        <div class="flex items-center gap-2">
-          <span class="text-2xl font-bold text-neutral-800">{{ event.genre }}</span>
-          <span class="text-2xl font-bold text-neutral-800">{{ event.title }}</span>
-        </div>
-  
-        <!-- 날짜 & 상태 -->
-        <div class="flex items-center space-x-2 mt-2">
-          <span class="text-sm text-zinc-600">{{ event.period }}</span>
-          <span v-if="event.isOngoing" class="px-2 py-0.5 text-sm text-white bg-violet-400 rounded-full">진행중</span>
-          <span v-if="event.score" class="flex items-center text-yellow-500 text-sm font-semibold">
-            ⭐ {{ event.score }}
-          </span>
-          <span class="text-purple-500">❤️</span>
-          <span class="text-purple-500">🔔</span>
-        </div>
-  
-        <!-- 공연 메타 정보 -->
-        <div class="mt-6 p-4 bg-white rounded-xl shadow-sm">
-          <div class="grid grid-cols-2 gap-y-2 gap-x-2 text-sm">
-            <div class="flex">
-              <span class="w-24 font-bold text-neutral-800 truncate">공연 시간</span>
-              <span class="text-zinc-600">{{ event.duration }}</span>
-            </div>
-            <div class="flex">
-              <span class="w-24 font-bold text-neutral-800 truncate">가 격</span>
-              <span class="text-zinc-600">{{ event.price }}</span>
-            </div>
-            <div class="flex">
-              <span class="w-24 font-bold text-neutral-800 truncate">관람 연령</span>
-              <span class="text-zinc-600">{{ event.ageLimit }}</span>
-            </div>
-            <div class="flex">
-              <span class="w-24 font-bold text-neutral-800 truncate">선 예매</span>
-              <span class="text-zinc-600">{{ event.bookingEarly?.period }}</span>
-            </div>
-            <div class="flex">
-              <span class="w-24 font-bold text-neutral-800 truncate">장 소</span>
-              <span class="text-zinc-600">{{ event.venue }}</span>
-            </div>
-            <div class="flex">
-              <span class="w-24 font-bold text-neutral-800 truncate">일반 예매</span>
-              <span class="text-zinc-600">{{ event.bookingNormal?.period }}</span>
-            </div>
+
+      <!-- 날짜 & 상태 -->
+      <div class="flex items-center space-x-2 mt-2">
+        <span class="text-sm text-zinc-600">{{ event.period }}</span>
+        <span
+          v-if="event.isOngoing"
+          class="px-2 py-0.5 text-sm text-white bg-violet-400 rounded-full"
+          >진행중</span
+        >
+        <span
+          v-if="event.score"
+          class="flex items-center text-yellow-500 text-sm font-semibold"
+        >
+          ⭐ {{ event.score }}
+        </span>
+        <span class="text-purple-500">❤️</span>
+        <span class="text-purple-500">🔔</span>
+      </div>
+
+      <!-- 공연 메타 정보 -->
+      <div class="mt-6 p-4 bg-white rounded-xl shadow-sm">
+        <div class="grid grid-cols-2 gap-y-2 gap-x-2 text-sm">
+          <div class="flex">
+            <span class="w-24 font-bold text-neutral-800 truncate"
+              >공연 시간</span
+            >
+            <span class="text-zinc-600">{{ event.duration }}</span>
+          </div>
+          <div class="flex">
+            <span class="w-24 font-bold text-neutral-800 truncate">가 격</span>
+            <span class="text-zinc-600">{{ event.price }}</span>
+          </div>
+          <div class="flex">
+            <span class="w-24 font-bold text-neutral-800 truncate"
+              >관람 연령</span
+            >
+            <span class="text-zinc-600">{{ event.ageLimit }}</span>
+          </div>
+          <div class="flex">
+            <span class="w-24 font-bold text-neutral-800 truncate"
+              >선 예매</span
+            >
+            <span class="text-zinc-600">{{ event.bookingEarly?.period }}</span>
+          </div>
+          <div class="flex">
+            <span class="w-24 font-bold text-neutral-800 truncate">장 소</span>
+            <span class="text-zinc-600">{{ event.venue }}</span>
+          </div>
+          <div class="flex">
+            <span class="w-24 font-bold text-neutral-800 truncate"
+              >일반 예매</span
+            >
+            <span class="text-zinc-600">{{ event.bookingNormal?.period }}</span>
           </div>
         </div>
       </div>
     </div>
-  </template>
-  
-  <script setup>
-  defineProps({
-    event: Object
-  })
-  </script>
-  
-  <style scoped>
-  /* 필요시 추가 스타일 */
-  </style>
-  
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  event: Object,
+});
+</script>
+
+<style scoped>
+/* 필요시 추가 스타일 */
+</style>


### PR DESCRIPTION
## #️⃣ Issue Number
#166 공연/전시 상세정보 페이지에서 간단정보 헤더 포스터 부분 수정
## 📝 요약(Summary)
간단정보 헤더의 포스터 부분을 디자인 수정 (노란 배경 제거, 포스터 이미지가 full로 차도록)

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 
## 💬 공유사항 to 리뷰어
이미지가 조금 잘려도 Full로 차도록 하는 것이 나은지, 아니면 네모칸을 세로로 좀 더 길게 해서 잘리지 않도록 하는것이 좋을지 의견 부탁드립니다~

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.