### PR TITLE
[#217] 사이드바 채팅의 로그인한 사용자가 참여한 채팅방 목록

### DIFF
--- a/src/stores/useChatStore.js
+++ b/src/stores/useChatStore.js
@@ -1,0 +1,14 @@
+import { defineStore } from 'pinia'
+import axios from 'axios'
+
+export const useChatStore = defineStore('chat', {
+  state: () => ({
+    myRooms: []
+  }),
+  actions: {
+    async fetchMyRooms() {
+      const res = await axios.get('/api/chat/list/my-rooms', { withCredentials: true })
+      this.myRooms = res.data
+    }
+  }
+})


### PR DESCRIPTION
## #️⃣ Issue Number
#217 사이드바 채팅의 로그인 한 사용자가 참여한 채팅방 목록
## 📝 요약(Summary)
사이드바의 채팅 부분은 로그인 한 사용자만 볼 수 있기 때문에 로그인 한 사용자가 참여하고 있는 채팅방 목록을 띄우도록 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정


## 📸스크린샷 (선택)
![image](https://github.com/user-attachments/assets/eedef41a-54dc-4158-8317-6ef5112425e5)


## 💬 공유사항 to 리뷰어
혹시라도 오류가 난다면 알려주시기 바랍니다~

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.